### PR TITLE
[PIPE-810] Update notifier name

### DIFF
--- a/bin/bugsnag-upload-report
+++ b/bin/bugsnag-upload-report
@@ -156,9 +156,9 @@ module BugsnagAppleReporter
       end
       {
         notifier: {
-          name: 'iOS Bugsnag Notifier',
+          name: 'iOS Bugsnag Crash Report Upload Tool',
           url: 'https://github.com/bugsnag/bugsnag-cocoa',
-          version: '5.15.4',
+          version: '1.0.0',
         },
         events: [event],
       }


### PR DESCRIPTION
Updates the notifier name in the generated output as the event-worker will use that name to trigger specific behaviour (for symbolicating dylibs).