### PR TITLE
Fix compatibility with recent iOS versions

### DIFF
--- a/bin/bugsnag-upload-report
+++ b/bin/bugsnag-upload-report
@@ -141,9 +141,10 @@ module BugsnagAppleReporter
       end
       report.backtraces.each do |backtrace|
         backtrace[:stacktrace].each do |frame|
-          if image = report.binary_images[frame[:machoLoadAddress]]
+          if image = report.binary_images[frame[:machoFile]]
             frame[:machoFile] = image[:path]
             frame[:machoUUID] = image[:uuid]
+            frame[:machoLoadAddress] = image[:addr]
           end
           frame[:isPC] = true if frame[:frameAddress] == report.program_counter
           frame[:isLR] = true if frame[:frameAddress] == report.link_register
@@ -160,7 +161,7 @@ module BugsnagAppleReporter
         notifier: {
           name: 'iOS Bugsnag Crash Report Upload Tool',
           url: 'https://github.com/bugsnag/bugsnag-cocoa',
-          version: '1.0.0',
+          version: '1.0.1',
         },
         events: [event],
       }
@@ -206,13 +207,14 @@ module BugsnagAppleReporter
     # Matches a frame in a stacktrace in the format:
     #
     #   2   libdispatch.dylib 0x00000001836a9e58 0x1836a5000 + 20056
+    #   3   libobjc.A.dylib 0x190dddefc _objc_terminate() + 160
     #
     # $1 - Frame number
     # $2 - Binary name
     # $3 - Frame address
-    # $4 - Image address
+    # $4 - Image address if unsymbolicated, or symbol name
     # $5 - Offset (diff between frame address and image address)
-    THREAD_FRAME_MATCHER = /^(\d+)\s+([^\s]+)\s+(0x[0-9a-f]+)\s(0x[0-9a-f]+)\s\+\s(\d+)/
+    THREAD_FRAME_MATCHER = /^(\d+)\s+([^\s]+)\s+(0x[0-9a-f]+)\s(.+)\s\+\s(\d+)/
     REGISTER_STATE_MATCHER = /Thread State.*:$/
     IMAGE_STATE_MATCHER = /Binary Images:/
     # Matches a single register value
@@ -224,7 +226,7 @@ module BugsnagAppleReporter
     # $2 - Name
     # $3 - UUID
     # $4 - File path
-    IMAGE_MATCHER = /^(0x[0-f]+)\s\-\s0x[0-f]+\s([^ ]+)\s\w+\s+<([0-9a-fA-F]+)>\s+(.*)/
+    IMAGE_MATCHER = /(0x[0-f]+)\s+\-\s+0x[0-f]+\s([^ ]+)\s\w+\s+<([0-9a-fA-F]+)>\s+(.*)/
 
     def parse_header contents
       while @state == :header and contents.length > 0
@@ -258,8 +260,7 @@ module BugsnagAppleReporter
           current_backtrace[:stacktrace] << {
             machoFile: $2,
             frameAddress: $3,
-            method: $3,
-            machoLoadAddress: $4,
+            method: $3
           }
         when ""
           current_backtrace = nil
@@ -301,7 +302,8 @@ module BugsnagAppleReporter
           # Potentially unreasonable assumption that the first image is the
           # host app's image
           report.app_uuid = uuid if report.binary_images.empty?
-          report.binary_images[$1] = {
+          report.binary_images[File.basename($4)] = {
+            addr: $1,
             name: $2,
             uuid: uuid,
             path: $4


### PR DESCRIPTION
## Goal

Fix compatibility with crash reports from more recent iOS versions.

## Changeset

Amends regexes to accommodate small changes in the format.

### Thread stack frames

Updates the pattern to allow matching symbolicated crash reports, e.g:

```
iOS 12:
0   libsystem_kernel.dylib        	0x00000001b43830dc 0x1b4360000 + 143580

iOS 16:
0   libsystem_kernel.dylib        	       0x1d40ee200 __pthread_kill + 8
```

The load address is not present in symbolicated frames so the file name is now used to find the associated binary image.

### Binary images

Updates the pattern to accommodate whitespace changes.

```
iOS 12:
0x1007e8000 - 0x10083ffff dyld arm64  <933d737bc53f31cf9fcd3a1875e80848> /usr/lib/dyld
0x1b394f000 - 0x1b3950fff libSystem.B.dylib arm64  <efc87cf1eb4b3bfca2245a34bd9ce4e5> /usr/lib/libSystem.B.dylib

iOS 16:
       0x1d40e7000 -        0x1d411dffb libsystem_kernel.dylib arm64e  <a5d3b72578c33e19a765cceb22355093> /usr/lib/system/libsystem_kernel.dylib
       0x1e4324000 -        0x1e432ffff libsystem_pthread.dylib arm64e  <b89b9a5b55d93e84b6d3c3da93c1cd39> /usr/lib/system/libsystem_pthread.dylib
```

## Testing

Tested by running locally with sample crash reports from devices running iOS 9, 12 & 16.