### PR TITLE
[PLAT-9066] Use CrashReporter Key as device.id

### DIFF
--- a/bin/bugsnag-upload-report
+++ b/bin/bugsnag-upload-report
@@ -127,6 +127,7 @@ module BugsnagAppleReporter
           dsymUUIDs: [ report.app_uuid ],
         },
         device: {
+          id: report.header.delete("CrashReporter Key"),
           model: report.header.delete("Hardware Model"),
           osName: os[1],
           osVersion: os[2],
@@ -161,7 +162,7 @@ module BugsnagAppleReporter
         notifier: {
           name: 'iOS Bugsnag Crash Report Upload Tool',
           url: 'https://github.com/bugsnag/bugsnag-cocoa',
-          version: '1.0.1',
+          version: '1.0.2',
         },
         events: [event],
       }


### PR DESCRIPTION
## Goal

Improve ingestion of Apple crash reports.

## Changeset

If present, uses the `CrashReporter Key` (a per-device unique identifier) for `device.id`.

## Testing

Tested locally against crash reports from iOS 9, 12 & 16.